### PR TITLE
Fixed Copy to Clipboard not copying newlines

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -269,7 +269,7 @@ document.getElementById("copyASCII").addEventListener("click", function () {
 
 document.getElementById("clipboardASCII").addEventListener("click", function () {
     const textArea = document.createElement("textarea");
-    textArea.textContent = document.getElementsByTagName("td")[0].textContent;
+    textArea.textContent = document.getElementsByTagName("td")[0].innerText;
     document.body.appendChild(textArea);
     textArea.select();
     document.execCommand('copy');


### PR DESCRIPTION
Fixes #4

Packed with webpack@5.72.0, three@0.139.2, html2canvas@1.4.1

Tested on Firefox 99.0.1 and Edge 100.0.1185.50