### PR TITLE
Fix pointLight cords

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -26,7 +26,7 @@ const scene = new THREE.Scene()
 scene.background = new THREE.Color(0, 0, 0);
 
 //Lights
-const pointLight1 = new THREE.PointLight(0xffffff, 1);
+const pointLight1 = new THREE.PointLight(0xffffff, 1, 0, 0);
 pointLight1.position.set(100, 100, 400);
 scene.add(pointLight1);
 


### PR DESCRIPTION
"three": "^0.165.0"
I don't know why, but the model only shows up if I add these arguments.